### PR TITLE
Skip t/07-debugger.t when PERL5DB is set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ MANIFEST*
 Debian*
 README
 namespace-clean-*
+nytprof.out

--- a/t/07-debugger.t
+++ b/t/07-debugger.t
@@ -9,6 +9,9 @@ BEGIN {
   ) {
     plan skip_all => $missing_xs;
   }
+  elsif ( defined $ENV{PERL5DB} ) {
+    plan skip_all => "custom ENV{PERL5DB} set.";
+  }
   else {
     plan tests => 4;
   }


### PR DESCRIPTION
RT 127516

On a fresh perl installation, Devel::NYTProf is missing
and is not listed in TestRequires...
thus namespace::autoclean fails during unit test and cannot
be install...

List NYTProf as a recommends and skip the test if missing.

Upstream-URL: https://rt.cpan.org/Ticket/Display.html?id=127516