### PR TITLE
drop Package::Stash dependency

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -23,7 +23,6 @@ my %META = (
     },
     runtime => {
       requires => {
-        'Package::Stash' => '0.23',
         'B::Hooks::EndOfScope' => '0.12',
         'perl' => '5.008001',
       },


### PR DESCRIPTION
Package::Stash refuses to work with package names that are valid, and
can break on earlier perls. Rather than working around this, just work
with the symbol tree manually. Using Package::Stash doesn't make the
code significantly cleaner or easier to understand. Additionally,
Package::Stash brings in a larger dependency tree than is reasonable for
the work it does.